### PR TITLE
feat: modernize error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-bitintr = "0.3.0"
-itertools = "0.10.1"
+bitintr = "0.3"
+itertools = "0.10"
+thiserror = "1.0"
 
 [profile.test]
 opt-level = 0

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,90 +1,54 @@
-use std::error;
-use std::fmt;
-use std::io;
-use std::num::ParseIntError;
+use thiserror::Error;
 
 /// The error type for SFEN serialize/deserialize operations.
-#[derive(Debug, PartialEq, Eq)]
-pub struct SfenError {}
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum SfenError {
+    #[error("data fields are missing")]
+    MissingDataFields,
 
-impl fmt::Display for SfenError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "illegal SFEN string")
-    }
-}
+    #[error("an illegal piece notation is found")]
+    IllegalPieceType,
 
-impl error::Error for SfenError {
-    fn description(&self) -> &str {
-        "illegal SFEN string"
-    }
+    #[error("the side to move needs to be black or white")]
+    IllegalSideToMove,
 
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+    #[error("an illegal move count notation is found")]
+    IllegalMoveCount(#[from] std::num::ParseIntError),
 
-impl From<ParseIntError> for SfenError {
-    fn from(_: ParseIntError) -> SfenError {
-        SfenError {}
-    }
-}
+    #[error("an illegal move notation is found")]
+    IllegalMove,
 
-impl From<io::Error> for SfenError {
-    fn from(_: io::Error) -> SfenError {
-        SfenError {}
-    }
+    #[error("an illegal board state notation is found")]
+    IllegalBoardState,
 }
 
 /// Represents an error occurred during making a move.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum MoveError {
+    #[error("the king is in check")]
     InCheck,
+
+    #[error("nifu detected")]
     Nifu,
+
+    #[error("uchifuzume detected")]
     Uchifuzume,
+
+    #[error("perpetual check detected")]
     PerpetualCheckWin,
+
+    #[error("perpetual check detected")]
     PerpetualCheckLose,
+
+    #[error("not your turn")]
     EnemysTurn,
+
+    #[error("the piece can not move anymor")]
     NonMovablePiece,
+
+    #[error("the move is inconsistent with the current position: {0}")]
     Inconsistent(&'static str),
+
+    #[error("repetition detected")]
     Repetition,
-}
-
-impl fmt::Display for MoveError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            MoveError::InCheck => write!(f, "the king is in check"),
-            MoveError::Nifu => write!(f, "nifu detected"),
-            MoveError::Uchifuzume => write!(f, "uchifuzume detected"),
-            MoveError::PerpetualCheckWin => write!(f, "perpetual check detected"),
-            MoveError::PerpetualCheckLose => write!(f, "perpetual check detected"),
-            MoveError::EnemysTurn => write!(f, "not your turn"),
-            MoveError::NonMovablePiece => write!(f, "the piece can not move anymore"),
-            MoveError::Inconsistent(message) => write!(
-                f,
-                "the move is inconsistent with the current position: {}",
-                message
-            ),
-            MoveError::Repetition => write!(f, "repetition detected"),
-        }
-    }
-}
-
-impl error::Error for MoveError {
-    fn description(&self) -> &str {
-        match *self {
-            MoveError::InCheck => "the king is in check",
-            MoveError::Nifu => "nifu detected",
-            MoveError::Uchifuzume => "uchifuzume detected",
-            MoveError::PerpetualCheckWin => "perpetual check detected",
-            MoveError::PerpetualCheckLose => "perpetual check detected",
-            MoveError::EnemysTurn => "not your turn",
-            MoveError::NonMovablePiece => "the piece can not move anymore",
-            MoveError::Inconsistent(_) => "the move is inconsistent with the current position",
-            MoveError::Repetition => "repetition detected",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -691,19 +691,19 @@ impl Position {
         // Build the initial position, all parts are required.
         parts
             .next()
-            .ok_or(SfenError {})
+            .ok_or(SfenError::MissingDataFields)
             .and_then(|s| self.parse_sfen_board(s))?;
         parts
             .next()
-            .ok_or(SfenError {})
+            .ok_or(SfenError::MissingDataFields)
             .and_then(|s| self.parse_sfen_stm(s))?;
         parts
             .next()
-            .ok_or(SfenError {})
+            .ok_or(SfenError::MissingDataFields)
             .and_then(|s| self.parse_sfen_hand(s))?;
         parts
             .next()
-            .ok_or(SfenError {})
+            .ok_or(SfenError::MissingDataFields)
             .and_then(|s| self.parse_sfen_ply(s))?;
 
         self.sfen_history.clear();
@@ -721,7 +721,7 @@ impl Position {
                         Err(_) => break,
                     }
                 } else {
-                    return Err(SfenError {});
+                    return Err(SfenError::IllegalMove);
                 }
             }
         }
@@ -761,7 +761,7 @@ impl Position {
 
         for (i, row) in rows.enumerate() {
             if i >= 9 {
-                return Err(SfenError {});
+                return Err(SfenError::IllegalBoardState);
             }
 
             let mut j = 0;
@@ -776,7 +776,7 @@ impl Position {
                         if let Some(n) = n.to_digit(10) {
                             for _ in 0..n {
                                 if j >= 9 {
-                                    return Err(SfenError {});
+                                    return Err(SfenError::IllegalBoardState);
                                 }
 
                                 let sq = Square::new(8 - j, i as u8).unwrap();
@@ -789,14 +789,14 @@ impl Position {
                     s => match Piece::from_sfen(s) {
                         Some(mut piece) => {
                             if j >= 9 {
-                                return Err(SfenError {});
+                                return Err(SfenError::IllegalBoardState);
                             }
 
                             if is_promoted {
                                 if let Some(promoted) = piece.piece_type.promote() {
                                     piece.piece_type = promoted;
                                 } else {
-                                    return Err(SfenError {});
+                                    return Err(SfenError::IllegalPieceType);
                                 }
                             }
 
@@ -809,7 +809,7 @@ impl Position {
 
                             is_promoted = false;
                         }
-                        None => return Err(SfenError {}),
+                        None => return Err(SfenError::IllegalPieceType),
                     },
                 }
             }
@@ -822,7 +822,7 @@ impl Position {
         self.side_to_move = match s {
             "b" => Color::Black,
             "w" => Color::White,
-            _ => return Err(SfenError {}),
+            _ => return Err(SfenError::IllegalSideToMove),
         };
         Ok(())
     }
@@ -846,7 +846,7 @@ impl Position {
                         Some(p) => self
                             .hand
                             .set(p, if num_pieces == 0 { 1 } else { num_pieces }),
-                        None => return Err(SfenError {}),
+                        None => return Err(SfenError::IllegalPieceType),
                     };
                     num_pieces = 0;
                 }


### PR DESCRIPTION
Use `thiserror` crate to implement std::error::Error trait better.
Also separate error kinds to better reflect the root cause.
