### PR TITLE
fix: remove bitintr from dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-bitintr = "0.3"
 itertools = "0.13"
 thiserror = "1.0"
 

--- a/src/bitboard/bits.rs
+++ b/src/bitboard/bits.rs
@@ -7,6 +7,23 @@ pub trait Pext {
     fn pext(&self, mask: Self) -> Self;
 }
 
+fn pext_naive(value: u64, mask: u64) -> u64 {
+    let mut result = 0;
+    let mut bb = 1;
+    let mut mask = mask;
+
+    while mask != 0 {
+        let bit = mask & (!mask + 1);
+        if value & bit != 0 {
+            result |= bb;
+        }
+        mask &= mask - 1;
+        bb <<= 1;
+    }
+
+    result
+}
+
 impl Pext for u64 {
     /// If the CPU supports the BMI2 instruction set, this method uses
     /// the `_pext_u64` intrinsic for efficient extraction.
@@ -20,20 +37,6 @@ impl Pext for u64 {
     #[inline(always)]
     #[cfg(not(target_feature = "bmi2"))]
     fn pext(&self, mask: Self) -> Self {
-        let mut result = 0;
-        let mut bb = 1;
-        let mut mask = mask;
-        let value = *self;
-
-        while mask != 0 {
-            let bit = mask & (!mask + 1);
-            if value & bit != 0 {
-                result |= bb;
-            }
-            mask &= mask - 1;
-            bb <<= 1;
-        }
-
-        result
+        pext_naive(*self, mask)
     }
 }

--- a/src/bitboard/bits.rs
+++ b/src/bitboard/bits.rs
@@ -1,0 +1,31 @@
+pub trait Pext {
+    fn pext(&self, mask: Self) -> Self;
+}
+
+impl Pext for u64 {
+    #[inline(always)]
+    #[cfg(target_feature = "bmi2")]
+    fn pext(&self, mask: Self) -> Self {
+        unsafe { std::arch::x86_64::_pext_u64(*self, mask) }
+    }
+
+    #[inline(always)]
+    #[cfg(not(target_feature = "bmi2"))]
+    fn pext(&self, mask: Self) -> Self {
+        let mut result = 0;
+        let mut bb = 1;
+        let mut mask = mask;
+        let value = *self;
+
+        while mask != 0 {
+            let bit = mask & (!mask + 1);
+            if value & bit != 0 {
+                result |= bb;
+            }
+            mask &= mask - 1;
+            bb <<= 1;
+        }
+
+        result
+    }
+}

--- a/src/bitboard/bits.rs
+++ b/src/bitboard/bits.rs
@@ -40,3 +40,78 @@ impl Pext for u64 {
         pext_naive(*self, mask)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pext() {
+        // Test cases: (value, mask, expected)
+        let table: [(u64, u64, u64); _] = [
+            // mask is zero
+            (
+                0x0000_0000_0000_0000,
+                0x0000_0000_0000_0000,
+                0x0000_0000_0000_0000,
+            ),
+            (
+                0x1234_5678_9ABC_DEF0,
+                0x0000_0000_0000_0000,
+                0x0000_0000_0000_0000,
+            ),
+            (
+                0xFFFF_FFFF_FFFF_FFFF,
+                0x0000_0000_0000_0000,
+                0x0000_0000_0000_0000,
+            ),
+            // mask is all ones
+            (
+                0x0000_0000_0000_0000,
+                0xFFFF_FFFF_FFFF_FFFF,
+                0x0000_0000_0000_0000,
+            ),
+            (
+                0x1234_5678_9ABC_DEF0,
+                0xFFFF_FFFF_FFFF_FFFF,
+                0x1234_5678_9ABC_DEF0,
+            ),
+            (
+                0xFFFF_FFFF_FFFF_FFFF,
+                0xFFFF_FFFF_FFFF_FFFF,
+                0xFFFF_FFFF_FFFF_FFFF,
+            ),
+            // one-hot
+            (0b1010_1010, 0b0000_1000, 0b1),
+            (0b1010_1010, 0b0000_0100, 0b0),
+            (0b1010_1010, 0b0000_0010, 0b1),
+            (0b1010_1010, 0b0000_0001, 0b0),
+            // continuous ones
+            (0b1111_0000, 0b1111_0000, 0b1111),
+            (0b0000_1111, 0b0000_1111, 0b1111),
+            (0b1010_1010, 0b1111_0000, 0b1010),
+            (0b1010_1010, 0b0000_1111, 0b1010),
+            // alternating ones
+            (0b1111_0000, 0b1010_1010, 0b1100),
+            (0b1111_0000, 0b0101_0101, 0b1100),
+            (0b0000_1111, 0b1010_1010, 0b0011),
+            (0b0000_1111, 0b0101_0101, 0b0011),
+            // random values
+            (
+                0x243F_6A88_85A3_08D3,
+                0x1319_8A2E_0370_7344,
+                0x0000_0000_003B_4502,
+            ),
+            (
+                0xA409_3822_299F_31D0,
+                0x082E_FA98_EC4E_6C89,
+                0x0000_0000_0870_33A4,
+            ),
+        ];
+
+        for &(value, mask, expected) in &table {
+            let result = pext_naive(value, mask);
+            assert_eq!(expected, result, "value: {:b}, mask: {:b}", value, mask);
+        }
+    }
+}

--- a/src/bitboard/bits.rs
+++ b/src/bitboard/bits.rs
@@ -1,14 +1,22 @@
+//! Implementation of the special bitwise operations
+
+/// Trait providing the parallel bit extract (PEXT) operation.
+/// The PEXT operation extracts bits from a value according to a given mask,
+/// compressing them into the least significant bits of the result.
 pub trait Pext {
     fn pext(&self, mask: Self) -> Self;
 }
 
 impl Pext for u64 {
+    /// If the CPU supports the BMI2 instruction set, this method uses
+    /// the `_pext_u64` intrinsic for efficient extraction.
     #[inline(always)]
     #[cfg(target_feature = "bmi2")]
     fn pext(&self, mask: Self) -> Self {
         unsafe { std::arch::x86_64::_pext_u64(*self, mask) }
     }
 
+    /// Software fallback implementation of the PEXT operation.
     #[inline(always)]
     #[cfg(not(target_feature = "bmi2"))]
     fn pext(&self, mask: Self) -> Self {

--- a/src/bitboard/factory.rs
+++ b/src/bitboard/factory.rs
@@ -1,5 +1,5 @@
+use super::bits::Pext;
 use super::*;
-use bitintr::*;
 
 macro_rules! BitboardOr {
     ($lhs: expr, $rhs: expr) => {

--- a/src/bitboard/mod.rs
+++ b/src/bitboard/mod.rs
@@ -7,7 +7,7 @@ use super::{Color, PieceType, Square};
 /// Represents a board state in which each square takes two possible values, filled or empty.
 ///
 /// `Bitboard` implements [PEXT Bitboard](https://www.chessprogramming.org/BMI2#PEXTBitboards) which relies on [BMI2 instruction set](https://www.chessprogramming.org/BMI2).
-/// For environments which do not support BMI2, it will use software fallback methods. Thanks to [bitintr](https://github.com/gnzlbg/bitintr) crate.
+/// For environments which do not support BMI2, it will use software fallback methods.
 ///
 /// # Examples
 ///
@@ -333,6 +333,7 @@ fn square_bb(sq: Square) -> Bitboard {
     SQUARE_BB[sq.index()]
 }
 
+mod bits;
 mod factory;
 
 pub use self::factory::Factory;


### PR DESCRIPTION
`bitintr` is no longer maintained and requires patches to be applied in order to build.
Since shogi-rs only uses Pext, we will remove the dependency on bitintr by replacing Pext with our own implementation.

Note:
In addition to the naive implementation I implemented here, there is also a software implementation of pext that uses parallel prefix xor.
However, from my measurements, the naive implementation was faster.
I think this result was due to the small number of bits left standing in the calculation of the effect.