### PR TITLE
Switch dev container to bare-devcontainer rust image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
     "name": "Rust",
-    "image": "mcr.microsoft.com/devcontainers/rust:bullseye",
+    "image": "ghcr.io/bare-devcontainer/rust:trixie",
+    "postCreateCommand": "rustup show",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Use ghcr.io/bare-devcontainer/rust:trixie instead of the Microsoft
image. It only installs rustup, so add rust-toolchain.toml to pin the
stable channel with rustfmt and clippy components.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KdQ44ABichUnrG7H4pmPqX