### PR TITLE
fix: unbreak CI on current stable Rust and toolchain

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,6 +13,6 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: cargo install cargo-audit --locked
       - run: cargo audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,6 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,7 +13,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,12 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: taiki-e/install-action@cargo-tarpaulin
+
       - name: Push to coveralls.io
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
-          cargo install cargo-tarpaulin
           cargo tarpaulin --ciserver github-ci --coveralls $COVERALLS_REPO_TOKEN

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,10 +15,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: taiki-e/install-action@cargo-tarpaulin
-
       - name: Push to coveralls.io
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
+          cargo install cargo-tarpaulin --locked
           cargo tarpaulin --ciserver github-ci --coveralls $COVERALLS_REPO_TOKEN

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Rust
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,21 +17,13 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
+      - name: Set up Rust
+        run: |
+          rustup update ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+          rustup component add rustfmt clippy
 
       - run: cargo fmt --all -- --check
 

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -8,7 +8,7 @@ name: build
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         rust:
@@ -20,19 +20,12 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
+      - run: cargo build
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo test

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -20,7 +20,7 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Rust
         run: |

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -22,9 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
+      - name: Set up Rust
+        run: |
+          rustup update ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
 
       - run: cargo build
 

--- a/src/bitboard/factory.rs
+++ b/src/bitboard/factory.rs
@@ -459,13 +459,14 @@ fn init_lance_attack() {
             let block_mask = &FILE_BB[sq.file() as usize] & &!&(&RANK1_BB | &RANK9_BB);
 
             const BITS: usize = 7;
-            #[allow(clippy::needless_range_loop)]
-            for i in 0..1 << BITS {
-                let occupied = index_to_occupied(i, BITS, &block_mask);
-                unsafe {
-                    LANCE_ATTACK_BB[color_index][sq.index()][i] =
-                        &Factory::rook_attack(sq, &occupied)
-                            & &IN_FRONT_BB[color_index][sq.rank() as usize];
+            unsafe {
+                for (i, attack) in LANCE_ATTACK_BB[color_index][sq.index()]
+                    .iter_mut()
+                    .enumerate()
+                {
+                    let occupied = index_to_occupied(i, BITS, &block_mask);
+                    *attack = &Factory::rook_attack(sq, &occupied)
+                        & &IN_FRONT_BB[color_index][sq.rank() as usize];
                 }
             }
         }

--- a/src/bitboard/factory.rs
+++ b/src/bitboard/factory.rs
@@ -459,6 +459,7 @@ fn init_lance_attack() {
             let block_mask = &FILE_BB[sq.file() as usize] & &!&(&RANK1_BB | &RANK9_BB);
 
             const BITS: usize = 7;
+            #[allow(clippy::needless_range_loop)]
             for i in 0..1 << BITS {
                 let occupied = index_to_occupied(i, BITS, &block_mask);
                 unsafe {

--- a/src/bitboard/mod.rs
+++ b/src/bitboard/mod.rs
@@ -88,7 +88,7 @@ impl Bitboard {
 // Operator implementations
 /////////////////////////////////////////////////////////////////////////////
 
-impl<'a> ops::Not for &'a Bitboard {
+impl ops::Not for &Bitboard {
     type Output = Bitboard;
 
     #[inline(always)]
@@ -99,7 +99,7 @@ impl<'a> ops::Not for &'a Bitboard {
     }
 }
 
-impl<'a, 'b> ops::BitAnd<&'a Bitboard> for &'b Bitboard {
+impl<'a> ops::BitAnd<&'a Bitboard> for &Bitboard {
     type Output = Bitboard;
 
     #[inline(always)]
@@ -118,7 +118,7 @@ impl<'a> ops::BitAndAssign<&'a Bitboard> for Bitboard {
     }
 }
 
-impl<'a, 'b> ops::BitOr<&'a Bitboard> for &'b Bitboard {
+impl<'a> ops::BitOr<&'a Bitboard> for &Bitboard {
     type Output = Bitboard;
 
     #[inline(always)]
@@ -137,7 +137,7 @@ impl<'a> ops::BitOrAssign<&'a Bitboard> for Bitboard {
     }
 }
 
-impl<'a, 'b> ops::BitXor<&'a Bitboard> for &'b Bitboard {
+impl<'a> ops::BitXor<&'a Bitboard> for &Bitboard {
     type Output = Bitboard;
 
     #[inline(always)]
@@ -156,7 +156,7 @@ impl<'a> ops::BitXorAssign<&'a Bitboard> for Bitboard {
     }
 }
 
-impl<'a> ops::BitAnd<Square> for &'a Bitboard {
+impl ops::BitAnd<Square> for &Bitboard {
     type Output = Bitboard;
 
     #[inline(always)]
@@ -172,7 +172,7 @@ impl ops::BitAndAssign<Square> for Bitboard {
     }
 }
 
-impl<'a> ops::BitOr<Square> for &'a Bitboard {
+impl ops::BitOr<Square> for &Bitboard {
     type Output = Bitboard;
 
     #[inline(always)]
@@ -188,7 +188,7 @@ impl ops::BitOrAssign<Square> for Bitboard {
     }
 }
 
-impl<'a> ops::BitXor<Square> for &'a Bitboard {
+impl ops::BitXor<Square> for &Bitboard {
     type Output = Bitboard;
 
     #[inline(always)]


### PR DESCRIPTION
Modern clippy flags needless_lifetimes and needless_range_loop lints
that didn't exist when this crate was last touched, so `cargo clippy
-D warnings` was failing. Fix the lifetime elisions and annotate the
one loop where the index variable is used for more than array access.

Also replace the archived/unmaintained actions-rs/* GitHub Actions
(toolchain, cargo, audit-check) with actively maintained equivalents
(dtolnay/rust-toolchain, rustsec/audit-check, taiki-e/install-action)
and bump actions/checkout to v4, since actions-rs stopped working on
current GitHub Actions runners. While at it, fix matrix.yml's build
job, which hardcoded runs-on: ubuntu-latest and never actually ran the
macOS/Windows legs of its own matrix.