### PR TITLE
ci: migrate coverage reporting from Coveralls to GitHub Code Coverage

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
+                "anthropic.claude-code",
                 "EditorConfig.EditorConfig"
             ],
             "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,10 @@
 {
     "name": "Rust",
     "image": "ghcr.io/bare-devcontainer/rust:trixie",
+    "remoteEnv": {
+        "EDITOR": "code --wait",
+        "VISUAL": "code --wait"
+    },
     "postCreateCommand": "rustup show",
     "customizations": {
         "vscode": {

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,11 @@ on:
 
 name: coverage
 
+permissions:
+  contents: read
+  code-quality: write
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,9 +20,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Push to coveralls.io
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      - name: Generate coverage report
         run: |
           cargo install cargo-tarpaulin --locked
-          cargo tarpaulin --ciserver github-ci --coveralls $COVERALLS_REPO_TOKEN
+          cargo tarpaulin --ciserver github-ci --out Xml
+
+      - name: Upload coverage report to GitHub
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@82c7aee3fb2ad768e00b00a0a8d749c5815085b6 # v1
+        with:
+          file: cobertura.xml
+          language: Rust
+          label: code-coverage/tarpaulin

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,19 +1,19 @@
+name: coverage
+
 on:
   push:
     branches:
       - main
   pull_request:
 
-name: coverage
-
-permissions:
-  contents: read
-  code-quality: write
-  pull-requests: read
+permissions: {}
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
+    environment: codecov
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -25,10 +25,7 @@ jobs:
           cargo install cargo-tarpaulin --locked
           cargo tarpaulin --ciserver github-ci --out Xml
 
-      - name: Upload coverage report to GitHub
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/upload-code-coverage@82c7aee3fb2ad768e00b00a0a8d749c5815085b6 # v1
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          file: cobertura.xml
-          language: Rust
-          label: code-coverage/tarpaulin
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Github Actions](https://github.com/nozaq/shogi-rs/workflows/build/badge.svg)](https://github.com/nozaq/shogi-rs/actions?workflow=build)
 [![crates.io](https://img.shields.io/crates/v/shogi.svg)](https://crates.io/crates/shogi)
 [![docs.rs](https://docs.rs/shogi/badge.svg)](https://docs.rs/shogi)
+[![codecov](https://codecov.io/github/nozaq/shogi-rs/graph/badge.svg?token=DNCQ0BSNWr)](https://codecov.io/github/nozaq/shogi-rs)
 
 A Bitboard-based shogi library in Rust. Board representation, move generation/validation and time control utilities.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # shogi-rs
 
 [![Github Actions](https://github.com/nozaq/shogi-rs/workflows/build/badge.svg)](https://github.com/nozaq/shogi-rs/actions?workflow=build)
-[![Coverage Status](https://coveralls.io/repos/github/nozaq/shogi-rs/badge.svg)](https://coveralls.io/github/nozaq/shogi-rs)
 [![crates.io](https://img.shields.io/crates/v/shogi.svg)](https://crates.io/crates/shogi)
 [![docs.rs](https://docs.rs/shogi/badge.svg)](https://docs.rs/shogi)
 

--- a/README.tpl
+++ b/README.tpl
@@ -1,7 +1,6 @@
 # shogi-rs
 
 [![Github Actions](https://github.com/nozaq/shogi-rs/workflows/build/badge.svg)](https://github.com/nozaq/shogi-rs/actions?workflow=build)
-[![Coverage Status](https://coveralls.io/repos/github/nozaq/shogi-rs/badge.svg)](https://coveralls.io/github/nozaq/shogi-rs)
 [![crates.io](https://img.shields.io/crates/v/shogi.svg)](https://crates.io/crates/shogi)
 [![docs.rs](https://docs.rs/shogi/badge.svg)](https://docs.rs/shogi)
 


### PR DESCRIPTION
## Summary
This PR migrates the project's code coverage reporting infrastructure from Coveralls.io to GitHub's native code coverage integration.

## Key Changes
- **Workflow permissions**: Added explicit permissions to the coverage workflow (`contents: read`, `code-quality: write`, `pull-requests: read`) to support GitHub Code Coverage integration
- **Coverage generation**: Updated the coverage step to generate Cobertura XML format (`--out Xml`) instead of pushing directly to Coveralls
- **Coverage upload**: Replaced direct Coveralls token-based push with GitHub's `upload-code-coverage` action for native GitHub integration
- **Conditional upload**: Added a condition to only upload coverage on push events or pull requests from the same repository
- **Documentation**: Removed Coveralls badge from README.md and README.tpl as it's no longer used

## Implementation Details
- The coverage workflow now generates a `cobertura.xml` file using `cargo-tarpaulin`
- Coverage reports are uploaded to GitHub using the official `actions/upload-code-coverage` action (pinned to v1)
- The Rust language is explicitly specified in the upload configuration
- Removed dependency on `COVERALLS_REPO_TOKEN` secret, simplifying credential management

https://claude.ai/code/session_01Mv2cxDWTAVS8AYwpZ2LAyT